### PR TITLE
move to lib

### DIFF
--- a/src/LogisticVRGDA.sol
+++ b/src/LogisticVRGDA.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 import {wadLn, unsafeDiv, unsafeWadDiv} from "./utils/SignedWadMath.sol";
 
+import {LogisticVRGDALib} from "./library/LogisticVRGDALib.sol";
 import {VRGDA} from "./VRGDA.sol";
 
 /// @title Logistic Variable Rate Gradual Dutch Auction
@@ -58,8 +59,6 @@ abstract contract LogisticVRGDA is VRGDA {
     /// @return The target time the tokens should be sold by, scaled by 1e18, where the time is
     /// relative, such that 0 means the tokens should be sold immediately when the VRGDA begins.
     function getTargetSaleTime(int256 sold) public view virtual override returns (int256) {
-        unchecked {
-            return -unsafeWadDiv(wadLn(unsafeDiv(logisticLimitDoubled, sold + logisticLimit) - 1e18), timeScale);
-        }
+        return LogisticVRGDALib.getTargetSaleTime(logisticLimitDoubled, logisticLimit, timeScale, sold);
     }
 }

--- a/src/VRGDA.sol
+++ b/src/VRGDA.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0;
 
 import {wadExp, wadLn, wadMul, unsafeWadMul, toWadUnsafe} from "./utils/SignedWadMath.sol";
 
+import {VRGDALib} from "./library/VRGDALib.sol";
+
 /// @title Variable Rate Gradual Dutch Auction
 /// @author transmissions11 <t11s@paradigm.xyz>
 /// @author FrankieIsLost <frankie@paradigm.xyz>
@@ -41,15 +43,13 @@ abstract contract VRGDA {
     /// @param sold The total number of tokens that have been sold so far.
     /// @return The price of a token according to VRGDA, scaled by 1e18.
     function getVRGDAPrice(int256 timeSinceStart, uint256 sold) public view virtual returns (uint256) {
-        unchecked {
-            // prettier-ignore
-            return uint256(wadMul(targetPrice, wadExp(unsafeWadMul(decayConstant,
-                // Theoretically calling toWadUnsafe with sold can silently overflow but under
-                // any reasonable circumstance it will never be large enough. We use sold + 1 as
-                // the VRGDA formula's n param represents the nth token and sold is the n-1th token.
-                timeSinceStart - getTargetSaleTime(toWadUnsafe(sold + 1))
-            ))));
-        }
+        return
+            VRGDALib.getVRGDAPrice(
+                timeSinceStart,
+                targetPrice,
+                decayConstant,
+                getTargetSaleTime(toWadUnsafe(sold + 1))
+            );
     }
 
     /// @dev Given a number of tokens sold, return the target time that number of tokens should be sold by.

--- a/src/library/LogisticVRGDALib.sol
+++ b/src/library/LogisticVRGDALib.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {wadExp, wadLn, wadMul, unsafeWadMul, unsafeWadDiv, toWadUnsafe, unsafeDiv} from "../utils/SignedWadMath.sol";
+
+import {VRGDALib} from "./VRGDALib.sol";
+
+/// @title Linear Variable Rate Gradual Dutch Auction
+/// @author transmissions11 <t11s@paradigm.xyz>
+/// @author FrankieIsLost <frankie@paradigm.xyz>
+/// @notice VRGDA with a linear issuance curve.
+library LogisticVRGDALib {
+    /*//////////////////////////////////////////////////////////////
+                              PRICING LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Calculate the price of a token according to the VRGDA formula.
+    /// @param timeSinceStart Time passed since the VRGDA began, scaled by 1e18.
+    /// @param targetPrice The target price for a token if sold on pace, scaled by 1e18.
+    /// @param decayConstant The percent price decays per unit of time with no sales, scaled by 1e18.
+    /// @return The price of a token according to VRGDA, scaled by 1e18.
+    function getVRGDAPrice(
+        int256 timeSinceStart,
+        int256 targetPrice,
+        int256 decayConstant,
+        int256 targetSaleTime
+    ) public pure returns (uint256) {
+        return VRGDALib.getVRGDAPrice(timeSinceStart, targetPrice, decayConstant, targetSaleTime);
+    }
+
+    /// @dev Given a number of tokens sold, return the target time that number of tokens should be sold by.
+    /// @param sold A number of tokens sold, scaled by 1e18, to get the corresponding target sale time for.
+    /// @return The target time the tokens should be sold by, scaled by 1e18, where the time is
+    /// relative, such that 0 means the tokens should be sold immediately when the VRGDA begins.
+    function getTargetSaleTime(
+        int256 logisticLimitDoubled,
+        int256 logisticLimit,
+        int256 timeScale,
+        int256 sold
+    ) public pure returns (int256) {
+        unchecked {
+            return -unsafeWadDiv(wadLn(unsafeDiv(logisticLimitDoubled, sold + logisticLimit) - 1e18), timeScale);
+        }
+    }
+}

--- a/src/library/VRGDALib.sol
+++ b/src/library/VRGDALib.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {wadExp, wadLn, wadMul, unsafeWadMul, unsafeWadDiv, toWadUnsafe} from "../utils/SignedWadMath.sol";
+
+/// @title Linear Variable Rate Gradual Dutch Auction
+/// @author transmissions11 <t11s@paradigm.xyz>
+/// @author FrankieIsLost <frankie@paradigm.xyz>
+/// @notice VRGDA with a linear issuance curve.
+library VRGDALib {
+    /*//////////////////////////////////////////////////////////////
+                              PRICING LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Calculate the price of a token according to the VRGDA formula.
+    /// @param timeSinceStart Time passed since the VRGDA began, scaled by 1e18.
+    /// @param targetPrice The target price for a token if sold on pace, scaled by 1e18.
+    /// @param decayConstant Precomputed constant that allows us to rewrite a pow() as an exp().
+    /// @param targetSaleTime target time the tokens should be sold by, scaled by 1e18.
+    /// @return The price of a token according to VRGDA, scaled by 1e18.
+    function getVRGDAPrice(
+        int256 timeSinceStart,
+        int256 targetPrice,
+        int256 decayConstant,
+        int256 targetSaleTime
+    ) public pure returns (uint256) {
+        unchecked {
+            // prettier-ignore
+            return uint256(wadMul(targetPrice, wadExp(unsafeWadMul(decayConstant,
+                // Theoretically calling toWadUnsafe with sold can silently overflow but under
+                // any reasonable circumstance it will never be large enough. We use sold + 1 as
+                // the VRGDA formula's n param represents the nth token and sold is the n-1th token.
+                timeSinceStart - targetSaleTime
+            ))));
+        }
+    }
+
+    /// @dev Calculate constant that allows us to rewrite a pow() as an exp().
+    /// @param priceDecayPercent The percent price decays per unit of time with no sales, scaled by 1e18.
+    /// @return The computed constant represented as an 18 decimal fixed point number.
+    function computeDecayConstant(int256 priceDecayPercent) public pure returns (int256) {
+        return wadLn(1e18 - priceDecayPercent);
+    }
+}


### PR DESCRIPTION
another potential solution of #12 

stateless - abstract common funcs out into a lib - anyone that wants to have more auctions just implements their own vrgdas and uses lib directly (similar to what we talked about0

This is just for logisitcVRGDA, we can do it for all the other auctions if this is the way we want to go.