### PR TITLE
change SLOAD to MLOAD

### DIFF
--- a/src/LogisticVRGDA.sol
+++ b/src/LogisticVRGDA.sol
@@ -44,7 +44,7 @@ abstract contract LogisticVRGDA is VRGDA {
         logisticLimit = _maxSellable + 1e18;
 
         // Scale by 2e18 to both double it and give it 36 decimals.
-        logisticLimitDoubled = logisticLimit * 2e18;
+        logisticLimitDoubled = (_maxSellable + 1e18) * 2e18;
 
         timeScale = _timeScale;
     }


### PR DESCRIPTION
Reading a state variable costs more gas than reading a local variable. If a state variable is read immediately after assignment, then replacing this read directly with the previously assigned local variable will change one SLOAD to one MLOAD to save some gases. 